### PR TITLE
Support for Bucket name.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,8 +36,10 @@ resource "aws_acm_certificate_validation" "main" {
 }
 
 resource "aws_s3_bucket" "website_bucket" {
-  bucket_prefix = "${var.name_prefix}-static-website-bucket"
   acl           = "private"
+
+  bucket_prefix = var.bucket_name == null ? "${var.name_prefix}-static-website-bucket" : null
+  bucket = var.bucket_name
 
   website {
     index_document = "index.html"

--- a/variables.tf
+++ b/variables.tf
@@ -28,3 +28,7 @@ variable "site_name" {
   type        = string
 }
 
+variable "bucket_name" {
+  description = "(Optional) A bucket name for the static website content. If this variable is not set a random name prefixed with <name_prefix>-static-website-bucket will be used.  "
+  default = null
+}


### PR DESCRIPTION
If the bucket_name variable has a value, it takes precedence over the default mechanism of using a random bucket name with a prefix concatenated by the value of "name_prefix" and the text literal "static-website-bucket"